### PR TITLE
feat(windows): Windows voice/PTT improvements and release bundling

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -63,6 +63,13 @@ jobs:
           New-Item -ItemType Directory -Force -Path $STAGE
           Copy-Item rs\target\release\clx-rust.exe  "$STAGE\clx.exe"
           Copy-Item rs\target\release\clx-screen-reader.exe "$STAGE\clx-screen-reader.exe"
+          # Runtime DLLs (sherpa-onnx-c-api.dll, onnxruntime.dll, etc.) are
+          # dropped by sherpa-rs's build.rs into target/release. Without these
+          # clx.exe fails with STATUS_DLL_NOT_FOUND (0xC0000135) at launch.
+          $dlls = Get-ChildItem rs\target\release -Filter *.dll -ErrorAction SilentlyContinue
+          if (-not $dlls) { throw "No DLLs found in rs\target\release — sherpa-rs build.rs may have failed" }
+          foreach ($d in $dlls) { Copy-Item $d.FullName "$STAGE\" }
+          Write-Host "Bundled DLLs: $($dlls.Name -join ', ')"
           Copy-Item scripts\install.ps1 "$STAGE\install.ps1"
           @"
           `$InstallDir = "`$env:LOCALAPPDATA\CapsLockX"
@@ -79,9 +86,13 @@ jobs:
       - name: Build NSIS setup.exe
         shell: pwsh
         run: |
-          # Stage binaries next to .nsi file (NSIS resolves File relative to script)
+          # Stage binaries + runtime DLLs next to .nsi (NSIS File resolves
+          # relative to script dir)
           Copy-Item rs\target\release\clx-rust.exe scripts\clx.exe
           Copy-Item rs\target\release\clx-screen-reader.exe scripts\clx-screen-reader.exe
+          Get-ChildItem rs\target\release -Filter *.dll | ForEach-Object {
+            Copy-Item $_.FullName "scripts\"
+          }
           # Install NSIS + EnVar plugin
           choco install nsis -y --no-progress
           $NSIS_DIR = "C:\Program Files (x86)\NSIS"

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           $STAGE = "CapsLockX"
           New-Item -ItemType Directory -Force -Path $STAGE
-          Copy-Item rs\target\release\clx-rust.exe  "$STAGE\clx.exe"
+          Copy-Item rs\target\release\clx.exe  "$STAGE\clx.exe"
           Copy-Item rs\target\release\clx-screen-reader.exe "$STAGE\clx-screen-reader.exe"
           # Runtime DLLs (sherpa-onnx-c-api.dll, onnxruntime.dll, etc.) are
           # dropped by sherpa-rs's build.rs into target/release. Without these
@@ -88,7 +88,7 @@ jobs:
         run: |
           # Stage binaries + runtime DLLs next to .nsi (NSIS File resolves
           # relative to script dir)
-          Copy-Item rs\target\release\clx-rust.exe scripts\clx.exe
+          Copy-Item rs\target\release\clx.exe scripts\clx.exe
           Copy-Item rs\target\release\clx-screen-reader.exe scripts\clx-screen-reader.exe
           Get-ChildItem rs\target\release -Filter *.dll | ForEach-Object {
             Copy-Item $_.FullName "scripts\"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ The `bin/clx` wrapper script sets `DYLD_LIBRARY_PATH` for onnxruntime.
 ```
 cargo build -p capslockx-windows --release
 ```
-Binary: `rs/target/release/clx-rust.exe`
+Binary: `rs/target/release/clx.exe`
 
 ## After fixing bugs / building
 **Always rebuild and relaunch after code changes — without being asked.**

--- a/Modules/CLX-Brainstorm.ahk
+++ b/Modules/CLX-Brainstorm.ahk
@@ -1,4 +1,4 @@
-; #Requires AutoHotkey v1.1.33
+﻿; #Requires AutoHotkey v1.1.33
 #Include ./Modules/Lib/AHK-GDIp-Library-Compilation/ahk-v1-1/Gdip_All.ahk ; https://github.com/marius-sucan/AHK-GDIp-Library-Compilation
 
 ; Note: This module uses Msxml2.XMLHTTP for HTTP requests

--- a/Modules/CLX-Settings.ahk
+++ b/Modules/CLX-Settings.ahk
@@ -70,13 +70,14 @@ CLX_ConfigWindow()
     Gui, Add, Button, w200 gButton添加开机自动启动, % t("添加开机自动启动")
     Gui, Add, Button, w200 gButtonSetupAutostart, % t("设置Windows自动启动")
     Gui, Add, Button, w200 gButton配置文件编辑, % t("配置文件编辑")
-    Gui, Add, Button, w200 gButton重新載入, % t("重新載入CapsLockX")
+    Gui, Add, Button, w95 gButton重新載入, % t("重新載入CapsLockX")
+    Gui, Add, Button, x+10 yp w95 gButtonExit, % t("退出")
     
     global T_TomatoLife ;
     if (T_TomatoLife) {
-        Gui, Add, CheckBox, gCLX_ConfigureUpdate vT_TomatoLife Checked, % t("启用番茄时钟，每25分钟休息5分钟·。")
+        Gui, Add, CheckBox, xm gCLX_ConfigureUpdate vT_TomatoLife Checked, % t("启用番茄时钟，每25分钟休息5分钟·。")
     } else {
-        Gui, Add, CheckBox, gCLX_ConfigureUpdate vT_TomatoLife, % t("启用番茄时钟，每25分钟休息5分钟·。")
+        Gui, Add, CheckBox, xm gCLX_ConfigureUpdate vT_TomatoLife, % t("启用番茄时钟，每25分钟休息5分钟·。")
     }
 
     global T_XKeyAsCapsLock
@@ -145,6 +146,10 @@ return
 Button重新載入:
     Func("CLX_Reload").Call()
     Reload
+return
+ButtonExit:
+    RunWait, taskkill /F /IM clx-rust.exe, , Hide
+    ExitApp
 return
 CLX_ConfigureUpdate:
     global T_TomatoLife

--- a/Modules/CLX-Settings.ahk
+++ b/Modules/CLX-Settings.ahk
@@ -148,7 +148,7 @@ Button重新載入:
     Reload
 return
 ButtonExit:
-    RunWait, taskkill /F /IM clx-rust.exe, , Hide
+    RunWait, taskkill /F /IM clx.exe, , Hide
     ExitApp
 return
 CLX_ConfigureUpdate:

--- a/Modules/CLX-WindowManager.ahk
+++ b/Modules/CLX-WindowManager.ahk
@@ -581,7 +581,7 @@ ArrangeWindowsSideBySide(listOfWindow, arrangeFlags = "0", MonitorIndex = "")
     }
 }
 ArrangeWindowsStacked(listOfWindow, arrangeFlags = "0", MonitorIndex = "")
-{    
+{
     arrangeFlags += 0 ; string to number
     n := StrSplit(listOfWindow, "`n", "`r").Count() - 1
     ; try parse work rect from monitor
@@ -598,7 +598,7 @@ ArrangeWindowsStacked(listOfWindow, arrangeFlags = "0", MonitorIndex = "")
         AreaH := MonitorWorkAreaBottom - MonitorWorkAreaTop
     }
     
-    dx := Min(48, AreaW / n)
+    dx := Min(96, AreaW / n)
     dy := Min(48, AreaH / n)
 
     if (arrangeFlags & ARRANGE_MOVING) {

--- a/rs/adapters/windows/Cargo.toml
+++ b/rs/adapters/windows/Cargo.toml
@@ -6,7 +6,7 @@ description = "CapsLockX Windows adapter – WH_KEYBOARD_LL hook + SendInput + T
 license = "GPL-3.0"
 
 [[bin]]
-name = "clx-rust"
+name = "clx"
 path = "src/main.rs"
 
 [build-dependencies]
@@ -33,4 +33,6 @@ windows = { version = "0.58", features = [
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_UI_Shell",
     "Win32_UI_Accessibility",
+    "Win32_System_DataExchange",
+    "Win32_Globalization",
 ] }

--- a/rs/adapters/windows/Cargo.toml
+++ b/rs/adapters/windows/Cargo.toml
@@ -35,4 +35,5 @@ windows = { version = "0.58", features = [
     "Win32_UI_Accessibility",
     "Win32_System_DataExchange",
     "Win32_Globalization",
+    "Win32_Media",
 ] }

--- a/rs/adapters/windows/src/config_store.rs
+++ b/rs/adapters/windows/src/config_store.rs
@@ -63,7 +63,7 @@ impl Default for FullConfig {
             page_speed:      30.0,
             tab_speed:       30.0,
             action_speed:    30.0,
-            mouse_speed:     1600.0,
+            mouse_speed:     4800.0,
             scroll_speed:    1600.0,
             request_admin:   false,
             stt_engine:      "sherpa".to_string(),

--- a/rs/adapters/windows/src/hook.rs
+++ b/rs/adapters/windows/src/hook.rs
@@ -112,22 +112,58 @@ pub fn install_hook() {
     };
     HOOK_RAW.store(hhook.0 as usize, Ordering::SeqCst);
 
-    // Drive AccModel ticks on the main/hook thread (16 ms timer).
-    // This replaces background ticker threads so SendInput runs on the same
-    // thread as the keyboard hook, avoiding phantom modifier key-up events.
+    // High-frequency ticker thread for AccModel physics (~166 FPS).
+    // Uses timeBeginPeriod(1) for 1ms Sleep resolution, then sleeps ~6ms
+    // per tick. SendInput for mouse movement works fine cross-thread.
+    // A low-frequency SetTimer (250ms) handles cursor-visibility nudges
+    // that don't need high frequency.
+    std::thread::Builder::new()
+        .name("clx-ticker".into())
+        .spawn(|| {
+            use std::sync::atomic::AtomicU64;
+            static TICK_COUNT: AtomicU64 = AtomicU64::new(0);
+            static LAST_LOG: AtomicU64 = AtomicU64::new(0);
+
+            // Request 1ms timer resolution from Windows.
+            unsafe {
+                windows::Win32::Media::timeBeginPeriod(1);
+            }
+
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(6)); // ~166 FPS
+
+                if let Some(engine) = ENGINE.get() {
+                    engine.tick();
+                }
+
+                // FPS logging — every 2 seconds.
+                let count = TICK_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64;
+                let last = LAST_LOG.load(Ordering::Relaxed);
+                if last == 0 {
+                    LAST_LOG.store(now_ms, Ordering::Relaxed);
+                    TICK_COUNT.store(0, Ordering::Relaxed);
+                } else if now_ms - last >= 2000 {
+                    let elapsed_s = (now_ms - last) as f64 / 1000.0;
+                    let fps = count as f64 / elapsed_s;
+                    debug_log(&format!("[CLX] tick: {:.1} FPS ({} ticks in {:.1}s)", fps, count, elapsed_s));
+                    LAST_LOG.store(now_ms, Ordering::Relaxed);
+                    TICK_COUNT.store(0, Ordering::Relaxed);
+                }
+            }
+        })
+        .expect("failed to spawn ticker thread");
+
+    // Low-frequency timer for cursor visibility nudges only.
     unsafe {
-        SetTimer(None, 0, 16, Some(tick_timer_proc));
+        SetTimer(None, 0, 250, Some(nudge_timer_proc));
     }
 }
 
-/// Timer callback — drives AccModel physics on the main/hook thread, and
-/// periodically nudges cursor visibility while CLX mode is held. Nudging used
-/// to happen inside the hook callback; moving it here keeps the hook callback
-/// fast and keeps us well under the WH_KEYBOARD_LL ~300 ms budget.
-unsafe extern "system" fn tick_timer_proc(_hwnd: HWND, _msg: u32, _id: usize, _time: u32) {
-    if let Some(engine) = ENGINE.get() {
-        engine.tick();
-    }
+unsafe extern "system" fn nudge_timer_proc(_hwnd: HWND, _msg: u32, _id: usize, _time: u32) {
     let active = LAST_TRAY_ACTIVE.load(Ordering::Relaxed);
     if active != 0 && active != u32::MAX {
         crate::cursor_visibility::nudge();

--- a/rs/adapters/windows/src/main.rs
+++ b/rs/adapters/windows/src/main.rs
@@ -54,19 +54,19 @@ pub fn update_tray_icon(active: bool) {
     }
 }
 
-/// Open (or focus) the preferences webview window. Same code path as the
-/// tray's "Preferences…" menu — used for the Space+, hotkey from
-/// `WinPlatform::open_preferences()`.
+/// Show the preferences webview window, creating it if it doesn't exist.
+/// Safe to call from any thread (hook callback, tray worker, menu handler).
+/// Window creation is deferred to a worker thread to avoid deadlocking when
+/// called from a thread that isn't pumping messages for the window.
 pub fn open_prefs_window() {
     let Some(app) = APP_HANDLE.get() else { return };
+    if let Some(w) = app.get_webview_window("prefs") {
+        let _ = w.show();
+        let _ = w.set_focus();
+        return;
+    }
     let app = app.clone();
-    // Tauri's webview construction must run off the hook thread; spawn.
     std::thread::spawn(move || {
-        if let Some(w) = app.get_webview_window("prefs") {
-            let _ = w.show();
-            let _ = w.set_focus();
-            return;
-        }
         use tauri::webview::WebviewWindowBuilder;
         use tauri::WebviewUrl;
         let _ = WebviewWindowBuilder::new(
@@ -244,30 +244,7 @@ fn main() {
                 .icon(icon)
                 .menu(&menu)
                 .on_menu_event(|app, event| match event.id().as_ref() {
-                    "prefs" => {
-                        // Re-show if already open.
-                        if let Some(w) = app.get_webview_window("prefs") {
-                            let _ = w.show();
-                            let _ = w.set_focus();
-                            return;
-                        }
-                        // Create on demand (must spawn thread to avoid deadlock on Windows).
-                        let app = app.clone();
-                        std::thread::spawn(move || {
-                            use tauri::webview::WebviewWindowBuilder;
-                            use tauri::WebviewUrl;
-                            let _ = WebviewWindowBuilder::new(
-                                &app,
-                                "prefs",
-                                WebviewUrl::App("index.html".into()),
-                            )
-                            .title("CapsLockX Preferences")
-                            .inner_size(560.0, 640.0)
-                            .resizable(false)
-                            .center()
-                            .build();
-                        });
-                    }
+                    "prefs" => open_prefs_window(),
                     "config_dir" => {
                         if let Some(dir) = config_store::config_path().parent() {
                             let _ = std::fs::create_dir_all(dir);

--- a/rs/adapters/windows/src/main.rs
+++ b/rs/adapters/windows/src/main.rs
@@ -54,6 +54,34 @@ pub fn update_tray_icon(active: bool) {
     }
 }
 
+/// Open (or focus) the preferences webview window. Same code path as the
+/// tray's "Preferences…" menu — used for the Space+, hotkey from
+/// `WinPlatform::open_preferences()`.
+pub fn open_prefs_window() {
+    let Some(app) = APP_HANDLE.get() else { return };
+    let app = app.clone();
+    // Tauri's webview construction must run off the hook thread; spawn.
+    std::thread::spawn(move || {
+        if let Some(w) = app.get_webview_window("prefs") {
+            let _ = w.show();
+            let _ = w.set_focus();
+            return;
+        }
+        use tauri::webview::WebviewWindowBuilder;
+        use tauri::WebviewUrl;
+        let _ = WebviewWindowBuilder::new(
+            &app,
+            "prefs",
+            WebviewUrl::App("index.html".into()),
+        )
+        .title("CapsLockX Preferences")
+        .inner_size(560.0, 640.0)
+        .resizable(false)
+        .center()
+        .build();
+    });
+}
+
 fn main() {
     // Log panics to file since we're a windows subsystem app with no console.
     std::panic::set_hook(Box::new(|info| {

--- a/rs/adapters/windows/src/output.rs
+++ b/rs/adapters/windows/src/output.rs
@@ -98,6 +98,9 @@ fn mouse_inp(dx: i32, dy: i32, data: i32, flags: u32) -> INPUT {
 // ── Platform impl ─────────────────────────────────────────────────────────────
 
 impl Platform for WinPlatform {
+    fn open_preferences(&self) {
+        crate::open_prefs_window();
+    }
     fn key_down(&self, key: KeyCode) {
         send(&[kbd(keycode_to_vk(key), KEYBD_EVENT_FLAGS(0))]);
     }

--- a/rs/adapters/windows/src/output.rs
+++ b/rs/adapters/windows/src/output.rs
@@ -12,11 +12,17 @@ use windows::Win32::Graphics::Gdi::{
 use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYBD_EVENT_FLAGS,
-    KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN,
+    KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE,
+    MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN,
     MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MOVE, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP,
     MOUSEEVENTF_WHEEL, MOUSE_EVENT_FLAGS, MOUSEINPUT, VIRTUAL_KEY, SendInput,
     GetAsyncKeyState,
 };
+use windows::Win32::System::DataExchange::{
+    OpenClipboard, CloseClipboard, EmptyClipboard, GetClipboardData, SetClipboardData,
+};
+use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+use windows::Win32::Foundation::HGLOBAL;
 use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_CLOAKED};
 use windows::Win32::UI::WindowsAndMessaging::{
     EnumWindows, GetForegroundWindow, GetWindowLongW, GetWindowTextLengthW,
@@ -101,6 +107,8 @@ impl Platform for WinPlatform {
     fn open_preferences(&self) {
         crate::open_prefs_window();
     }
+
+
     fn key_down(&self, key: KeyCode) {
         send(&[kbd(keycode_to_vk(key), KEYBD_EVENT_FLAGS(0))]);
     }
@@ -150,6 +158,111 @@ impl Platform for WinPlatform {
     fn is_key_physically_down(&self, key: KeyCode) -> bool {
         let vk = keycode_to_vk(key) as i32;
         unsafe { GetAsyncKeyState(vk) < 0 }
+    }
+
+    /// Type a Unicode string using SendInput with KEYEVENTF_UNICODE.
+    /// Supports full Unicode including CJK, emoji, etc.
+    fn type_text(&self, text: &str) {
+        let mut inputs = Vec::new();
+        for ch in text.chars() {
+            let mut utf16_buf = [0u16; 2];
+            let units = ch.encode_utf16(&mut utf16_buf);
+            for &code_unit in units.iter() {
+                inputs.push(INPUT {
+                    r#type: INPUT_KEYBOARD,
+                    Anonymous: INPUT_0 {
+                        ki: KEYBDINPUT {
+                            wVk: VIRTUAL_KEY(0),
+                            wScan: code_unit,
+                            dwFlags: KEYEVENTF_UNICODE,
+                            time: 0,
+                            dwExtraInfo: CLX_EXTRA_INFO,
+                        },
+                    },
+                });
+                inputs.push(INPUT {
+                    r#type: INPUT_KEYBOARD,
+                    Anonymous: INPUT_0 {
+                        ki: KEYBDINPUT {
+                            wVk: VIRTUAL_KEY(0),
+                            wScan: code_unit,
+                            dwFlags: KEYEVENTF_UNICODE | KEYEVENTF_KEYUP,
+                            time: 0,
+                            dwExtraInfo: CLX_EXTRA_INFO,
+                        },
+                    },
+                });
+            }
+        }
+        if !inputs.is_empty() {
+            send(&inputs);
+        }
+    }
+
+    fn get_clipboard_text(&self) -> String {
+        unsafe {
+            if OpenClipboard(HWND(std::ptr::null_mut())).is_err() {
+                return String::new();
+            }
+            let result = (|| {
+                let handle = GetClipboardData(13); // CF_UNICODETEXT = 13
+                let handle = match handle {
+                    Ok(h) => HGLOBAL(h.0),
+                    Err(_) => return String::new(),
+                };
+                let ptr = GlobalLock(handle) as *const u16;
+                if ptr.is_null() { return String::new(); }
+                let mut len = 0;
+                while *ptr.add(len) != 0 { len += 1; }
+                let slice = std::slice::from_raw_parts(ptr, len);
+                let result = String::from_utf16_lossy(slice);
+                let _ = GlobalUnlock(handle);
+                result
+            })();
+            let _ = CloseClipboard();
+            result
+        }
+    }
+
+    fn set_clipboard_text(&self, text: &str) {
+        let utf16: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
+        let byte_len = utf16.len() * 2;
+        unsafe {
+            let hmem = GlobalAlloc(GMEM_MOVEABLE, byte_len);
+            let hmem = match hmem {
+                Ok(h) => h,
+                Err(_) => return,
+            };
+            let ptr = GlobalLock(hmem) as *mut u16;
+            if ptr.is_null() { return; }
+            std::ptr::copy_nonoverlapping(utf16.as_ptr(), ptr, utf16.len());
+            let _ = GlobalUnlock(hmem);
+            if OpenClipboard(HWND(std::ptr::null_mut())).is_ok() {
+                let _ = EmptyClipboard();
+                let _ = SetClipboardData(13, windows::Win32::Foundation::HANDLE(hmem.0)); // CF_UNICODETEXT
+                let _ = CloseClipboard();
+            }
+        }
+    }
+
+    fn get_selected_text(&self) -> String {
+        // Save current clipboard, send Ctrl+C, read clipboard, restore old clipboard.
+        let old = self.get_clipboard_text();
+        // Clear clipboard first so we can detect if Ctrl+C wrote something.
+        unsafe {
+            if OpenClipboard(HWND(std::ptr::null_mut())).is_ok() {
+                let _ = EmptyClipboard();
+                let _ = CloseClipboard();
+            }
+        }
+        self.key_tap_cmd_or_ctrl(KeyCode::C);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let selected = self.get_clipboard_text();
+        // Restore old clipboard.
+        if !old.is_empty() {
+            self.set_clipboard_text(&old);
+        }
+        selected
     }
 
     fn mouse_move(&self, dx: i32, dy: i32) {

--- a/rs/adapters/windows/src/shm.rs
+++ b/rs/adapters/windows/src/shm.rs
@@ -39,12 +39,12 @@ unsafe impl Send for SharedState {}
 unsafe impl Sync for SharedState {}
 
 impl SharedState {
-    /// Kill every other `clx-rust.exe` instance on the system, plus any
+    /// Kill every other `clx.exe` instance on the system, plus any
     /// orphaned AHK child whose pid is recorded in the previous shared
     /// memory header. Strategy:
     ///   1. Signal the named `CapsLockX_Quit` event once — every previous
     ///      instance that's listening will call `app.exit()` cleanly.
-    ///   2. Enumerate `clx-rust.exe` processes via Toolhelp32, skipping our
+    ///   2. Enumerate `clx.exe` processes via Toolhelp32, skipping our
     ///      own pid. For each: wait briefly for graceful exit, then
     ///      `TerminateProcess` as fallback.
     /// This catches multi-instance / orphan / crashed-prior-state cases
@@ -55,7 +55,7 @@ impl SharedState {
     pub fn kill_previous() -> bool {
         let mut needs_elevation = false;
         crate::hook::debug_log(&format!(
-            "[CLX] kill_previous: scanning for old clx-rust.exe (self_pid={})",
+            "[CLX] kill_previous: scanning for old clx.exe (self_pid={})",
             std::process::id()
         ));
         unsafe {
@@ -85,7 +85,7 @@ impl SharedState {
                 let _ = CloseHandle(evt);
             }
 
-            // ── Step 2: enumerate every clx-rust.exe and kill it ───────
+            // ── Step 2: enumerate every clx.exe and kill it ───────
             let self_pid = std::process::id();
             let snap = match CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) {
                 Ok(h) if h != INVALID_HANDLE_VALUE => h,
@@ -102,7 +102,7 @@ impl SharedState {
                 loop {
                     let len = entry.szExeFile.iter().position(|&c| c == 0).unwrap_or(0);
                     let name = String::from_utf16_lossy(&entry.szExeFile[..len]);
-                    if name.eq_ignore_ascii_case("clx-rust.exe")
+                    if name.eq_ignore_ascii_case("clx.exe")
                         && entry.th32ProcessID != self_pid
                     {
                         victims.push(entry.th32ProcessID);

--- a/rs/adapters/windows/src/vk.rs
+++ b/rs/adapters/windows/src/vk.rs
@@ -137,7 +137,6 @@ pub fn keycode_to_vk(key: KeyCode) -> u16 {
         KeyCode::VolumeDown => 0xAE,
         KeyCode::VolumeMute => 0xAD,
 
-        KeyCode::Comma => 0xBC, // VK_OEM_COMMA
         KeyCode::Unknown(v) => v as u16,
     }
 }

--- a/rs/core/src/modules/mod.rs
+++ b/rs/core/src/modules/mod.rs
@@ -12,28 +12,120 @@ pub mod voice_ptt;
 mod voice_ptt_test;
 #[cfg(not(feature = "stt"))]
 mod voice {
-    //! No-op stub used when the `stt` feature is disabled (e.g. Windows
-    //! builds, where `whisper-rs 0.13` fails to compile). Mirrors the
-    //! public surface of `VoiceModule` so the rest of `Modules` compiles
-    //! unchanged. All hotkeys silently fall through.
+    //! Otoji-only voice module for builds without in-process STT (e.g.
+    //! Windows, where whisper-rs 0.13 fails to compile on MSVC).
+    //! Delegates all speech recognition to the external `otoji` binary
+    //! via voice_otoji + voice_ptt.
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex;
+    use std::time::Instant;
     use crate::key_code::KeyCode;
-    use crate::platform::Platform;
+    use crate::platform::{Platform, PttTrayState};
 
-    pub struct VoiceModule;
+    pub struct VoiceModule {
+        platform: Arc<dyn Platform>,
+        otoji: Arc<super::voice_otoji::OtojiBackend>,
+        otoji_available: bool,
+        otoji_typed: Arc<Mutex<String>>,
+        ptt: Arc<super::voice_ptt::PttSession>,
+        input_active: Arc<AtomicBool>,
+        v_held: Arc<AtomicBool>,
+        note_active: Arc<AtomicBool>,
+        press_time: Mutex<Option<Instant>>,
+    }
 
     impl VoiceModule {
-        pub fn with_stt_engine(_platform: Arc<dyn Platform>, _stt_engine: String) -> Self {
-            Self
+        pub fn with_stt_engine(platform: Arc<dyn Platform>, _stt_engine: String) -> Self {
+            let otoji = Arc::new(super::voice_otoji::OtojiBackend::new());
+            let ptt = super::voice_ptt::PttSession::new(
+                Arc::clone(&platform),
+                Arc::clone(&otoji),
+            );
+            let available = super::voice_otoji::OtojiBackend::is_available();
+            if available {
+                eprintln!("[CLX] voice(otoji-only): otoji detected on PATH");
+            } else {
+                eprintln!("[CLX] voice(otoji-only): otoji NOT found — Space+V disabled");
+            }
+            Self {
+                platform,
+                otoji,
+                otoji_available: available,
+                otoji_typed: Arc::new(Mutex::new(String::new())),
+                ptt,
+                input_active: Arc::new(AtomicBool::new(false)),
+                v_held: Arc::new(AtomicBool::new(false)),
+                note_active: Arc::new(AtomicBool::new(false)),
+                press_time: Mutex::new(None),
+            }
         }
+
         pub fn with_llm_config(self, _api_key: String, _model: String, _correction: bool) -> Self {
             self
         }
-        pub fn preload(&self) {}
-        pub fn on_key_down(&self, _key: KeyCode) -> bool { false }
-        pub fn on_key_up(&self, _key: KeyCode) -> bool { false }
-        pub fn is_mapped_key(&self, _key: KeyCode) -> bool { false }
-        pub fn stop(&self) {}
+
+        pub fn preload(&self) {
+            if self.otoji_available {
+                eprintln!("[CLX] voice(otoji-only): skipping in-process STT preload");
+            }
+        }
+
+        pub fn on_key_down(&self, key: KeyCode) -> bool {
+            if key != KeyCode::V { return false; }
+            if !self.otoji_available { return false; }
+
+            *self.press_time.lock().unwrap() = Some(Instant::now());
+            self.v_held.store(true, Ordering::Relaxed);
+
+            if self.ptt.on_press() {
+                return true;
+            }
+
+            self.ensure_otoji_running();
+            true
+        }
+
+        pub fn on_key_up(&self, key: KeyCode) -> bool {
+            if key != KeyCode::V { return false; }
+            if !self.otoji_available { return false; }
+
+            self.v_held.store(false, Ordering::Relaxed);
+
+            let result = self.ptt.on_release();
+            match result {
+                super::voice_ptt::PttRelease::Hold => {
+                    eprintln!("[CLX] voice: hold release → waiting for otoji ptt_final");
+                    if !self.note_active.load(Ordering::Relaxed) {
+                        self.platform.hide_voice_overlay();
+                    }
+                }
+                super::voice_ptt::PttRelease::Locked => {
+                    eprintln!("[CLX] voice: double-tap → PTT locked mode");
+                }
+                super::voice_ptt::PttRelease::Tap => {
+                    if self.note_active.load(Ordering::Relaxed) {
+                        self.note_active.store(false, Ordering::Relaxed);
+                        self.platform.hide_voice_overlay();
+                        self.platform.set_ptt_tray_state(PttTrayState::Idle);
+                    } else {
+                        self.note_active.store(true, Ordering::Relaxed);
+                        self.platform.show_voice_overlay();
+                        self.platform.set_ptt_tray_state(PttTrayState::NoteMode);
+                    }
+                }
+            }
+            true
+        }
+
+        pub fn is_mapped_key(&self, key: KeyCode) -> bool {
+            key == KeyCode::V && self.otoji_available
+        }
+
+        pub fn stop(&self) {
+            self.otoji.stop();
+        }
+
         #[allow(clippy::too_many_arguments)]
         pub fn update_config(
             &self,
@@ -43,6 +135,30 @@ mod voice {
             _speech_start_prob: f32, _speech_end_prob: f32,
             _speech_start_frames: usize, _silence_end_frames: usize,
         ) {}
+
+        fn ensure_otoji_running(&self) {
+            if self.otoji.is_running() { return; }
+
+            eprintln!("[CLX] voice(otoji-only): launching otoji backend");
+            self.platform.show_voice_overlay();
+            self.platform.update_voice_subtitle("otoji starting...");
+            *self.otoji_typed.lock().unwrap() = String::new();
+
+            let otoji = Arc::clone(&self.otoji);
+            let platform = Arc::clone(&self.platform);
+            let input_active = Arc::clone(&self.input_active);
+            let otoji_typed = Arc::clone(&self.otoji_typed);
+            let ptt = Arc::clone(&self.ptt);
+            std::thread::Builder::new()
+                .name("otoji-launch".into())
+                .spawn(move || {
+                    if !otoji.start(platform.clone(), input_active, otoji_typed, Some(ptt)) {
+                        eprintln!("[CLX] voice(otoji-only): otoji failed to start");
+                        platform.update_voice_subtitle("otoji failed");
+                    }
+                })
+                .ok();
+        }
     }
 }
 pub mod window_manager;

--- a/rs/core/src/modules/voice.rs
+++ b/rs/core/src/modules/voice.rs
@@ -319,6 +319,7 @@ impl VoiceModule {
     /// Check if voice-standalone is running via PID file.
     /// Uses kill(pid, 0) syscall instead of spawning a subprocess — safe for
     /// the CGEventTap callback which must return in <500ms.
+    #[cfg(unix)]
     fn voice_standalone_pid() -> Option<u32> {
         let pid_str = std::fs::read_to_string("/tmp/clx-voice-standalone.pid").ok()?;
         let pid = pid_str.trim().parse::<u32>().ok()?;
@@ -327,11 +328,18 @@ impl VoiceModule {
         if alive { Some(pid) } else { None }
     }
 
+    #[cfg(not(unix))]
+    fn voice_standalone_pid() -> Option<u32> { None }
+
     /// Send a Unix signal to a process (best-effort, no subprocess spawn).
+    #[cfg(unix)]
     fn send_signal(pid: u32, sig: i32) {
         extern "C" { fn kill(pid: i32, sig: i32) -> i32; }
         unsafe { kill(pid as i32, sig); }
     }
+
+    #[cfg(not(unix))]
+    fn send_signal(_pid: u32, _sig: i32) {}
 
     pub fn on_key_down(&self, key: KeyCode) -> bool {
         if key != KeyCode::V {
@@ -394,28 +402,28 @@ impl VoiceModule {
 
         match ptt_result {
             PttRelease::Hold => {
-                // Hold release: otoji will send ptt_final asynchronously.
-                // Do NOT stop the pipeline — otoji needs to stay alive to
-                // deliver the event, and to be ready for the next PTT press.
                 eprintln!("[CLX] voice: hold release → waiting for otoji ptt_final");
-                self.platform.hide_voice_overlay();
+                // Only hide the overlay if note mode isn't keeping it visible.
+                if !self.note_active.load(Ordering::Relaxed) {
+                    self.platform.hide_voice_overlay();
+                }
             }
             PttRelease::Locked => {
-                // Double-tap: entered locked PTT mode, or already locked.
-                // Keep pipeline running for mic feed. Don't toggle note.
                 eprintln!("[CLX] voice: double-tap → PTT locked mode");
             }
             PttRelease::Tap => {
-                // Single tap: toggle voice NOTE mode.
-                // Do NOT stop the otoji pipeline — it must stay alive for
-                // PTT signals. Only toggle the overlay and note flag.
+                // Single tap: toggle voice NOTE mode (live subtitles in overlay).
+                use super::super::platform::PttTrayState;
                 if self.note_active.load(Ordering::Relaxed) {
                     self.note_active.store(false, Ordering::Relaxed);
                     eprintln!("[CLX] voice: click → note stopped");
                     self.platform.hide_voice_overlay();
+                    self.platform.set_ptt_tray_state(PttTrayState::Idle);
                 } else {
                     self.note_active.store(true, Ordering::Relaxed);
                     eprintln!("[CLX] voice: click → note started");
+                    self.platform.show_voice_overlay();
+                    self.platform.set_ptt_tray_state(PttTrayState::NoteMode);
                 }
             }
         }

--- a/rs/core/src/modules/voice_otoji.rs
+++ b/rs/core/src/modules/voice_otoji.rs
@@ -89,6 +89,8 @@ fn write_wav_header(w: &mut impl Write) -> std::io::Result<()> {
 pub struct OtojiBackend {
     child: Mutex<Option<Child>>,
     reader_stop: Arc<AtomicBool>,
+    /// TCP control socket address (used on Windows instead of Unix signals).
+    control_addr: Mutex<Option<String>>,
 }
 
 impl OtojiBackend {
@@ -96,12 +98,44 @@ impl OtojiBackend {
         Self {
             child: Mutex::new(None),
             reader_stop: Arc::new(AtomicBool::new(false)),
+            control_addr: Mutex::new(None),
         }
     }
 
     /// Get the PID of the running otoji subprocess (for signal sending).
     pub fn pid(&self) -> Option<u32> {
         self.child.lock().unwrap().as_ref().map(|c| c.id())
+    }
+
+    /// Get the control socket address (for TCP-based PTT control on Windows).
+    pub fn control_addr(&self) -> Option<String> {
+        self.control_addr.lock().unwrap().clone()
+    }
+
+    /// Send a control command via TCP to the otoji control socket.
+    pub fn send_control(&self, cmd: &str) -> bool {
+        if let Some(addr) = self.control_addr() {
+            match std::net::TcpStream::connect_timeout(
+                &addr.parse().unwrap(),
+                std::time::Duration::from_millis(500),
+            ) {
+                Ok(mut stream) => {
+                    use std::io::Write;
+                    let msg = format!("{}\n", cmd);
+                    if stream.write_all(msg.as_bytes()).is_ok() {
+                        return true;
+                    }
+                    eprintln!("[CLX] voice-otoji: control write failed");
+                    false
+                }
+                Err(e) => {
+                    eprintln!("[CLX] voice-otoji: control connect failed: {}", e);
+                    false
+                }
+            }
+        } else {
+            false
+        }
     }
 
     /// Check if `otoji` binary is available on PATH.
@@ -161,12 +195,32 @@ impl OtojiBackend {
             }
         }
 
+        // On Windows, use TCP control socket instead of Unix signals for PTT.
+        #[cfg(target_os = "windows")]
+        let control_port = {
+            // Pick a random ephemeral port.
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").ok();
+            let port = listener.as_ref().map(|l| l.local_addr().unwrap().port()).unwrap_or(18080);
+            drop(listener);
+            let addr = format!("127.0.0.1:{}", port);
+            args.push("--ptt-control-socket".into());
+            args.push(addr.clone());
+            addr
+        };
+
         cmd.args(&args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::piped())
             .env("OTOJI_RELAUNCHED", "1")
             .env("OTOJI_REBUILDING", "1"); // prevent auto-rebuild + exec which breaks pipes
+
+        // On Windows, prevent a visible CMD window from flashing.
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        }
 
         // NOTE: process_group(0) was disabled — it may interfere with signal
         // delivery from parent to child on macOS. We kill otoji explicitly
@@ -182,6 +236,13 @@ impl OtojiBackend {
         };
 
         eprintln!("[CLX] voice-otoji: started otoji pid={}", child.id());
+
+        // Store the control socket address on Windows.
+        #[cfg(target_os = "windows")]
+        {
+            *self.control_addr.lock().unwrap() = Some(control_port);
+            eprintln!("[CLX] voice-otoji: control socket ready");
+        }
 
         let mut child = child;
         let stdout = child.stdout.take().expect("otoji stdout");

--- a/rs/core/src/modules/voice_otoji.rs
+++ b/rs/core/src/modules/voice_otoji.rs
@@ -24,6 +24,7 @@ enum AsrEvent {
     PttPartial { text: String },
     PttFinal { text: String },
     PttUpgrade { text: String },
+    PttTranslated { text: String, lang: String },
     Other,
 }
 
@@ -45,9 +46,13 @@ fn parse_event(line: &str) -> AsrEvent {
         "final"   => AsrEvent::Final   { text: get("text").unwrap_or_default() },
         "status"      => AsrEvent::Status      { message: get("message").unwrap_or_default() },
         "error"       => AsrEvent::Error       { message: get("message").unwrap_or_default() },
-        "ptt_partial" => AsrEvent::PttPartial  { text: get("text").unwrap_or_default() },
-        "ptt_final"   => AsrEvent::PttFinal    { text: get("text").unwrap_or_default() },
-        "ptt_upgrade" => AsrEvent::PttUpgrade  { text: get("text").unwrap_or_default() },
+        "ptt_partial"    => AsrEvent::PttPartial    { text: get("text").unwrap_or_default() },
+        "ptt_final"      => AsrEvent::PttFinal      { text: get("text").unwrap_or_default() },
+        "ptt_upgrade"    => AsrEvent::PttUpgrade    { text: get("text").unwrap_or_default() },
+        "ptt_translated" => AsrEvent::PttTranslated {
+            text: get("text").unwrap_or_default(),
+            lang: get("lang").unwrap_or_default(),
+        },
         _ => AsrEvent::Other,
     }
 }
@@ -127,17 +132,41 @@ impl OtojiBackend {
         // opening the mic itself. CLX has mic permission; otoji may not.
         let mut cmd = Command::new("otoji");
         let ctx_path = super::voice_ptt::ptt_context_file_path();
-        cmd.args([
-            "listen", "--plain", "-",
-            "--ptt-polish", "auto",  // fix punctuation (e.g. `.` → `?` for questions)
-            "--ptt-tts", "auto",     // speak the polished text back for pronunciation feedback
-            "--ptt-context-file", &ctx_path,
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdin(Stdio::piped())
-        .env("OTOJI_RELAUNCHED", "1")
-        .env("OTOJI_REBUILDING", "1"); // prevent auto-rebuild + exec which breaks pipes
+        let mut args: Vec<String> = vec![
+            "listen".into(), "--plain".into(), "-".into(),
+            // "openai" route goes through OpenAiPolisher which honors the
+            // OTOJI_POLISH_BASE_URL / _API_KEY / _MODEL env vars. Default
+            // in .env.local points to Cloudflare Workers AI (edge inference,
+            // ~200-500ms TTFB). Falls back to Gemini if those env vars are
+            // unset thanks to `resolve_polisher`'s "auto" chain.
+            "--ptt-polish".into(), "openai".into(),
+            // Gemini handles multilingual (en/zh/ja) — "auto" would pick Piper
+            // which is English-only and mangles CJK text.
+            "--ptt-tts".into(), "gemini".into(),
+            "--ptt-context-file".into(), ctx_path,
+        ];
+        // Translation (Phase 1: env-driven).
+        // CLX_TRANSLATE_TO: target language BCP-47 code (e.g. "en"). Empty = off.
+        // CLX_TRANSLATE_TTS_SOURCE: "original" or "translated" (default original).
+        if let Ok(to) = std::env::var("CLX_TRANSLATE_TO") {
+            if !to.is_empty() {
+                args.push("--ptt-translate-to".into());
+                args.push(to);
+            }
+        }
+        if let Ok(src) = std::env::var("CLX_TRANSLATE_TTS_SOURCE") {
+            if !src.is_empty() {
+                args.push("--ptt-tts-source".into());
+                args.push(src);
+            }
+        }
+
+        cmd.args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::piped())
+            .env("OTOJI_RELAUNCHED", "1")
+            .env("OTOJI_REBUILDING", "1"); // prevent auto-rebuild + exec which breaks pipes
 
         // NOTE: process_group(0) was disabled — it may interfere with signal
         // delivery from parent to child on macOS. We kill otoji explicitly
@@ -360,6 +389,11 @@ impl OtojiBackend {
                             AsrEvent::PttUpgrade { text } => {
                                 if let Some(ref p) = ptt {
                                     p.on_ptt_upgrade(&text);
+                                }
+                            }
+                            AsrEvent::PttTranslated { text, lang } => {
+                                if let Some(ref p) = ptt {
+                                    p.on_ptt_translated(&text, &lang);
                                 }
                             }
                             AsrEvent::Status { message } => {

--- a/rs/core/src/modules/voice_otoji.rs
+++ b/rs/core/src/modules/voice_otoji.rs
@@ -115,8 +115,15 @@ impl OtojiBackend {
     /// Send a control command via TCP to the otoji control socket.
     pub fn send_control(&self, cmd: &str) -> bool {
         if let Some(addr) = self.control_addr() {
+            let socket_addr: std::net::SocketAddr = match addr.parse() {
+                Ok(a) => a,
+                Err(e) => {
+                    eprintln!("[CLX] voice-otoji: invalid control address '{}': {}", addr, e);
+                    return false;
+                }
+            };
             match std::net::TcpStream::connect_timeout(
-                &addr.parse().unwrap(),
+                &socket_addr,
                 std::time::Duration::from_millis(500),
             ) {
                 Ok(mut stream) => {

--- a/rs/core/src/modules/voice_ptt.rs
+++ b/rs/core/src/modules/voice_ptt.rs
@@ -416,6 +416,9 @@ impl PttSession {
             .name("ptt-spinner".into())
             .spawn(move || {
                 let mut i = 0usize;
+                let spin_start = Instant::now();
+                let mut iter_no = 0u64;
+                let mut last_iter_end = spin_start;
                 // Type the initial frame under the lock.
                 {
                     let mut s = this.spinner.lock().unwrap();
@@ -426,11 +429,14 @@ impl PttSession {
                 }
                 loop {
                     std::thread::sleep(Duration::from_millis(SPINNER_INTERVAL_MS));
+                    let loop_top = Instant::now();
                     let mut s = this.spinner.lock().unwrap();
+                    let got_lock = Instant::now();
                     if !s.active { return; }
                     i = (i + 1) % SPINNER_FRAMES.len();
                     // Backspace old frame, type new. Under lock so stop_spinner
                     // can't race during the swap.
+                    let inject_start = Instant::now();
                     if let Some(old) = s.current.take() {
                         for _ in old.chars() {
                             this.platform.key_tap(KeyCode::Backspace);
@@ -438,7 +444,21 @@ impl PttSession {
                     }
                     let frame = SPINNER_FRAMES[i];
                     this.platform.type_text(frame);
+                    let inject_end = Instant::now();
                     s.current = Some(frame.to_string());
+                    drop(s);
+
+                    iter_no += 1;
+                    let gap = loop_top.duration_since(last_iter_end).as_millis();
+                    let lock_wait = got_lock.duration_since(loop_top).as_millis();
+                    let inject_ms = inject_end.duration_since(inject_start).as_millis();
+                    let since_start = loop_top.duration_since(spin_start).as_millis();
+                    // Log every iteration for now (we can throttle later once
+                    // the cause is clear).
+                    eprintln!(
+                        "[CLX] ptt-spin #{iter_no} t+{since_start}ms gap={gap}ms lock_wait={lock_wait}ms inject={inject_ms}ms"
+                    );
+                    last_iter_end = inject_end;
                 }
             })
             .ok();
@@ -504,7 +524,9 @@ impl PttSession {
 
     /// Replace displayed text at cursor using diff (common prefix optimization).
     fn replace_displayed(&self, new_text: &str) {
+        let t0 = Instant::now();
         let mut displayed = self.displayed.lock().unwrap();
+        let t_lock = Instant::now();
         let old = &**displayed;
 
         let common: usize = old.chars().zip(new_text.chars())
@@ -513,13 +535,25 @@ impl PttSession {
 
         let old_tail_chars = old.chars().count() - common;
         let new_tail: String = new_text.chars().skip(common).collect();
+        let new_tail_chars = new_tail.chars().count();
 
+        let t_inject_start = Instant::now();
         for _ in 0..old_tail_chars {
             self.platform.key_tap(KeyCode::Backspace);
         }
         if !new_tail.is_empty() {
             self.platform.type_text(&new_tail);
         }
+        let t_end = Instant::now();
+
+        eprintln!(
+            "[CLX] ptt-partial old_len={} new_len={} common={} bs={} type={} | lock={}ms inject={}ms total={}ms",
+            old.chars().count(), new_text.chars().count(), common,
+            old_tail_chars, new_tail_chars,
+            t_lock.duration_since(t0).as_millis(),
+            t_end.duration_since(t_inject_start).as_millis(),
+            t_end.duration_since(t0).as_millis(),
+        );
 
         *displayed = new_text.to_string();
     }

--- a/rs/core/src/modules/voice_ptt.rs
+++ b/rs/core/src/modules/voice_ptt.rs
@@ -481,22 +481,47 @@ impl PttSession {
 
     /// Send SIGUSR1 to otoji. Returns true if sent, false if no pid available.
     fn send_ptt_start(&self) -> bool {
-        if let Some(pid) = self.otoji.pid() {
-            eprintln!("[CLX] PTT: sending SIGUSR1 (ptt_start) to otoji pid={pid}");
-            Self::send_signal(pid, 10); // SIGUSR1
-            true
-        } else {
-            eprintln!("[CLX] PTT: no otoji pid available for ptt_start (will retry)");
-            false
+        // On Windows, use TCP control socket instead of Unix signals.
+        #[cfg(not(unix))]
+        {
+            if self.otoji.send_control("PTT_START") {
+                eprintln!("[CLX] PTT: sent PTT_START via control socket");
+                return true;
+            }
+            eprintln!("[CLX] PTT: control socket not ready for PTT_START (will retry)");
+            return false;
+        }
+        #[cfg(unix)]
+        {
+            if let Some(pid) = self.otoji.pid() {
+                eprintln!("[CLX] PTT: sending SIGUSR1 (ptt_start) to otoji pid={pid}");
+                Self::send_signal(pid, 10); // SIGUSR1
+                true
+            } else {
+                eprintln!("[CLX] PTT: no otoji pid available for ptt_start (will retry)");
+                false
+            }
         }
     }
 
     fn send_ptt_end(&self) {
-        if let Some(pid) = self.otoji.pid() {
-            eprintln!("[CLX] PTT: sending SIGUSR2 (ptt_end) to otoji pid={pid}");
-            Self::send_signal(pid, 12); // SIGUSR2
-        } else {
-            eprintln!("[CLX] PTT: no otoji pid available for ptt_end");
+        #[cfg(not(unix))]
+        {
+            if self.otoji.send_control("PTT_END") {
+                eprintln!("[CLX] PTT: sent PTT_END via control socket");
+            } else {
+                eprintln!("[CLX] PTT: control socket not ready for PTT_END");
+            }
+            return;
+        }
+        #[cfg(unix)]
+        {
+            if let Some(pid) = self.otoji.pid() {
+                eprintln!("[CLX] PTT: sending SIGUSR2 (ptt_end) to otoji pid={pid}");
+                Self::send_signal(pid, 12); // SIGUSR2
+            } else {
+                eprintln!("[CLX] PTT: no otoji pid available for ptt_end");
+            }
         }
     }
 
@@ -507,19 +532,9 @@ impl PttSession {
         }
         let ret = unsafe { kill(pid as i32, sig) };
         if ret != 0 {
-            // errno accessor is libc-specific (__error on macOS/BSD,
-            // __errno_location on glibc). std::io::Error does the right thing
-            // portably, so use that for the diagnostic.
             let err = std::io::Error::last_os_error();
             eprintln!("[CLX] PTT: kill({pid}, {sig}) FAILED: ret={ret}, err={err}");
         }
-    }
-
-    #[cfg(not(unix))]
-    fn send_signal(_pid: u32, _sig: i32) {
-        // Windows otoji handshake would use a named pipe or TCP socket rather
-        // than POSIX signals. PTT is a no-op on non-unix until that lands.
-        eprintln!("[CLX] PTT: send_signal skipped (non-unix platform)");
     }
 
     /// Replace displayed text at cursor using diff (common prefix optimization).

--- a/rs/core/src/modules/voice_ptt.rs
+++ b/rs/core/src/modules/voice_ptt.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::key_code::KeyCode;
-use crate::platform::Platform;
+use crate::platform::{Platform, PttTrayState};
 
 /// Delay before showing any placeholder — quick taps (<150ms) stay invisible.
 const PLACEHOLDER_DELAY_MS: u64 = 150;
@@ -46,6 +46,18 @@ pub enum PttRelease {
 
 // ── PttSession ───────────────────────────────────────────────────────────────
 
+/// Animated indicator typed at the cursor while background polish / TTS /
+/// translation is running. Shows the user something is in flight.
+struct SpinnerState {
+    active: bool,
+    /// The spinner glyph currently visible on screen (so we know what to
+    /// backspace when swapping frames or stopping). `None` = nothing typed.
+    current: Option<String>,
+}
+
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPINNER_INTERVAL_MS: u64 = 100;
+
 pub struct PttSession {
     platform: Arc<dyn Platform>,
     /// Currently displayed text at cursor (placeholder, partial, or final).
@@ -59,6 +71,9 @@ pub struct PttSession {
     /// Text that was last typed by `on_ptt_final` — used by `on_ptt_upgrade`
     /// to compute a minimal diff against the polished version.
     last_committed: Mutex<String>,
+    /// Spinner state — shows a live indicator char at the cursor while
+    /// polish / TTS / translation is running in the background.
+    spinner: Mutex<SpinnerState>,
     /// True once otoji's mic is ready (first status/partial received).
     mic_ready: Arc<AtomicBool>,
     /// Signals that a PTT session is active (between press and release/commit).
@@ -76,6 +91,7 @@ impl PttSession {
             locked: AtomicBool::new(false),
             last_tap_time: Mutex::new(None),
             last_committed: Mutex::new(String::new()),
+            spinner: Mutex::new(SpinnerState { active: false, current: None }),
             mic_ready: Arc::new(AtomicBool::new(false)),
             ptt_active: AtomicBool::new(false),
             otoji,
@@ -111,6 +127,7 @@ impl PttSession {
         let token = self.token_counter.fetch_add(1, Ordering::Relaxed) + 1;
         *self.displayed.lock().unwrap() = String::new();
         self.ptt_active.store(true, Ordering::Relaxed);
+        self.platform.set_ptt_tray_state(PttTrayState::Recording);
 
         // Fetch AX tree in background — completes during the user's speech
         // and becomes available to otoji (via ctx file) by the time the
@@ -229,7 +246,7 @@ impl PttSession {
 
     /// Called when otoji emits a `ptt_final` event — the RAW transcription,
     /// typed immediately while polish runs in the background.
-    pub fn on_ptt_final(&self, text: &str) {
+    pub fn on_ptt_final(self: &Arc<Self>, text: &str) {
         let text = text.trim();
         let old = {
             let mut d = self.displayed.lock().unwrap();
@@ -242,6 +259,26 @@ impl PttSession {
             eprintln!("[CLX] PTT: final (raw) -> {:?}", text);
             self.platform.type_text(text);
             *self.last_committed.lock().unwrap() = text.to_string();
+
+            // Tray: Recording -> Processing (polish/TTS still running async).
+            // Fall back to Idle after 3s if no upgrade arrives (polish may be
+            // disabled or may have returned text identical to raw).
+            self.platform.set_ptt_tray_state(PttTrayState::Processing);
+
+            // Start spinner — animated indicator at the cursor while polish/
+            // TTS/translation run in the background. Auto-stops via the 3s
+            // timer below (or sooner, when ptt_upgrade / ptt_translated arrive).
+            self.start_spinner();
+
+            let this = Arc::clone(self);
+            std::thread::Builder::new()
+                .name("ptt-tray-reset".into())
+                .spawn(move || {
+                    std::thread::sleep(Duration::from_secs(3));
+                    this.stop_spinner();
+                    this.platform.set_ptt_tray_state(PttTrayState::Idle);
+                })
+                .ok();
         }
 
         // (on_ptt_upgrade may arrive later with polished text — we diff-update there.)
@@ -254,11 +291,81 @@ impl PttSession {
         }
     }
 
+    /// Called when otoji emits a `ptt_translated` event. Behavior depends on
+    /// the translation config (env-driven in Phase 1):
+    ///
+    /// - `CLX_TRANSLATE_TYPE=original` (default): ignore — typed text stays
+    ///   in the source language.
+    /// - `CLX_TRANSLATE_TYPE=translated`: replace the already-typed original
+    ///   with the translation.
+    /// - `CLX_TRANSLATE_TYPE=both`: append the translation after the original,
+    ///   joined by `CLX_TRANSLATE_BOTH_TEMPLATE` (default `\n`) — or rendered
+    ///   via the template if it contains `__ORIGINAL__` / `__TRANSLATION__`.
+    pub fn on_ptt_translated(&self, translated: &str, _lang: &str) {
+        let translated = translated.trim();
+        if translated.is_empty() { return; }
+        self.stop_spinner();
+
+        let mode = std::env::var("CLX_TRANSLATE_TYPE").unwrap_or_else(|_| "original".into());
+        match mode.as_str() {
+            "translated" => {
+                // Replace original with translation (like ptt_upgrade).
+                let mut prev = self.last_committed.lock().unwrap();
+                if translated == *prev { return; }
+                let prev_chars = prev.chars().count();
+                let new_chars = translated.chars().count();
+                if (prev_chars as isize - new_chars as isize).abs() > 200 {
+                    eprintln!("[CLX] PTT: translation skipped — size delta too large");
+                    return;
+                }
+                let common: usize = prev.chars().zip(translated.chars())
+                    .take_while(|(a, b)| a == b).count();
+                let old_tail = prev_chars - common;
+                let new_tail: String = translated.chars().skip(common).collect();
+                for _ in 0..old_tail {
+                    self.platform.key_tap(KeyCode::Backspace);
+                }
+                if !new_tail.is_empty() {
+                    self.platform.type_text(&new_tail);
+                }
+                *prev = translated.to_string();
+                eprintln!("[CLX] PTT: translated → {:?}", translated);
+            }
+            "both" => {
+                // Append translation after original, using template.
+                let tmpl = std::env::var("CLX_TRANSLATE_BOTH_TEMPLATE")
+                    .unwrap_or_else(|_| "__ORIGINAL__\n__TRANSLATION__".into());
+                let orig = self.last_committed.lock().unwrap().clone();
+                let rendered = tmpl
+                    .replace("__ORIGINAL__", &orig)
+                    .replace("__TRANSLATION__", translated)
+                    .replace("\\n", "\n");
+                // Diff against what's already displayed (= orig).
+                let common: usize = orig.chars().zip(rendered.chars())
+                    .take_while(|(a, b)| a == b).count();
+                let old_tail = orig.chars().count() - common;
+                let new_tail: String = rendered.chars().skip(common).collect();
+                for _ in 0..old_tail {
+                    self.platform.key_tap(KeyCode::Backspace);
+                }
+                if !new_tail.is_empty() {
+                    self.platform.type_text(&new_tail);
+                }
+                *self.last_committed.lock().unwrap() = rendered;
+                eprintln!("[CLX] PTT: both (orig + translation) appended");
+            }
+            _ => {
+                // "original" or unknown — do nothing.
+            }
+        }
+    }
+
     /// Called when otoji emits a `ptt_upgrade` event — the polished version
     /// of the most recent `ptt_final`. Diff-updates the cursor: backspace the
     /// differing suffix, type the new suffix. Usually just a character or two.
     pub fn on_ptt_upgrade(&self, polished: &str) {
         let polished = polished.trim();
+        self.stop_spinner();
         let mut prev = self.last_committed.lock().unwrap();
         if polished == *prev || polished.is_empty() {
             return;
@@ -290,6 +397,64 @@ impl PttSession {
             self.platform.type_text(&new_tail);
         }
         *prev = polished.to_string();
+        // Upgrade finished — return tray to Idle (or NoteMode if active).
+        self.platform.set_ptt_tray_state(PttTrayState::Idle);
+    }
+
+    // ── Spinner ──────────────────────────────────────────────────────────
+
+    /// Start the animated polish/TTS spinner at the cursor. Idempotent —
+    /// does nothing if already active.
+    fn start_spinner(self: &Arc<Self>) {
+        {
+            let mut s = self.spinner.lock().unwrap();
+            if s.active { return; }
+            s.active = true;
+        }
+        let this = Arc::clone(self);
+        std::thread::Builder::new()
+            .name("ptt-spinner".into())
+            .spawn(move || {
+                let mut i = 0usize;
+                // Type the initial frame under the lock.
+                {
+                    let mut s = this.spinner.lock().unwrap();
+                    if !s.active { return; }
+                    let frame = SPINNER_FRAMES[i];
+                    this.platform.type_text(frame);
+                    s.current = Some(frame.to_string());
+                }
+                loop {
+                    std::thread::sleep(Duration::from_millis(SPINNER_INTERVAL_MS));
+                    let mut s = this.spinner.lock().unwrap();
+                    if !s.active { return; }
+                    i = (i + 1) % SPINNER_FRAMES.len();
+                    // Backspace old frame, type new. Under lock so stop_spinner
+                    // can't race during the swap.
+                    if let Some(old) = s.current.take() {
+                        for _ in old.chars() {
+                            this.platform.key_tap(KeyCode::Backspace);
+                        }
+                    }
+                    let frame = SPINNER_FRAMES[i];
+                    this.platform.type_text(frame);
+                    s.current = Some(frame.to_string());
+                }
+            })
+            .ok();
+    }
+
+    /// Stop the spinner and remove any currently-displayed frame from the
+    /// cursor. Safe to call multiple times.
+    fn stop_spinner(&self) {
+        let mut s = self.spinner.lock().unwrap();
+        if !s.active && s.current.is_none() { return; }
+        s.active = false;
+        if let Some(old) = s.current.take() {
+            for _ in old.chars() {
+                self.platform.key_tap(KeyCode::Backspace);
+            }
+        }
     }
 
     // ── Internal ─────────────────────────────────────────────────────────
@@ -315,16 +480,26 @@ impl PttSession {
         }
     }
 
+    #[cfg(unix)]
     fn send_signal(pid: u32, sig: i32) {
         extern "C" {
             fn kill(pid: i32, sig: i32) -> i32;
-            fn __error() -> *mut i32; // macOS errno
         }
         let ret = unsafe { kill(pid as i32, sig) };
         if ret != 0 {
-            let errno = unsafe { *__error() };
-            eprintln!("[CLX] PTT: kill({pid}, {sig}) FAILED: ret={ret}, errno={errno}");
+            // errno accessor is libc-specific (__error on macOS/BSD,
+            // __errno_location on glibc). std::io::Error does the right thing
+            // portably, so use that for the diagnostic.
+            let err = std::io::Error::last_os_error();
+            eprintln!("[CLX] PTT: kill({pid}, {sig}) FAILED: ret={ret}, err={err}");
         }
+    }
+
+    #[cfg(not(unix))]
+    fn send_signal(_pid: u32, _sig: i32) {
+        // Windows otoji handshake would use a named pipe or TCP socket rather
+        // than POSIX signals. PTT is a no-op on non-unix until that lands.
+        eprintln!("[CLX] PTT: send_signal skipped (non-unix platform)");
     }
 
     /// Replace displayed text at cursor using diff (common prefix optimization).

--- a/rs/core/src/platform.rs
+++ b/rs/core/src/platform.rs
@@ -27,6 +27,15 @@ pub trait SystemAudioStream: Send {
     fn sample_rate(&self) -> u32;
 }
 
+/// Menu bar / tray icon state for voice features.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PttTrayState {
+    Idle,
+    Recording,
+    Processing,
+    NoteMode,
+}
+
 pub trait Platform: Send + Sync + 'static {
     // ── Keyboard output ───────────────────────────────────────────────────────
 
@@ -191,6 +200,8 @@ pub trait Platform: Send + Sync + 'static {
     fn hide_voice_overlay(&self) {}
     fn update_voice_overlay(&self, _mic_levels: &[f32], _mic_vad: bool, _sys_levels: &[f32], _sys_vad: bool) {}
     fn update_voice_subtitle(&self, _text: &str) {}
+    /// Update the menu bar tray icon to reflect PTT / voice state.
+    fn set_ptt_tray_state(&self, _state: PttTrayState) {}
 
     // ── Brainstorm overlay (optional, default = no-op) ─────────────────────
 

--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -38,6 +38,11 @@ Section "Install"
   ; Copy files
   File "clx.exe"
   File "clx-screen-reader.exe"
+  ; sherpa-rs runtime DLLs (required — clx.exe fails with 0xC0000135 without
+  ; them). CI stages *.dll from rs/target/release/ next to this .nsi before
+  ; calling makensis, so the wildcard picks up sherpa-onnx-c-api.dll,
+  ; onnxruntime.dll, onnxruntime_providers_shared.dll, cargs.dll, etc.
+  File "*.dll"
 
   ; Create uninstaller
   WriteUninstaller "$INSTDIR\uninstall.exe"
@@ -76,6 +81,7 @@ Section "Uninstall"
   ; Remove files
   Delete "$INSTDIR\clx.exe"
   Delete "$INSTDIR\clx-screen-reader.exe"
+  Delete "$INSTDIR\*.dll"
   Delete "$INSTDIR\uninstall.exe"
   RMDir "$INSTDIR"
 


### PR DESCRIPTION
## Summary

- Windows: 166fps ticker, TCP PTT control socket, `CREATE_NO_WINDOW` flag
- Windows: wire otoji voice PTT, type_text, clipboard; rename binary to `clx`
- Windows: bundle sherpa-rs runtime DLLs in zip + installer
- Windows: fix Space+, hotkey → open preferences window
- Core: PttTrayState + PttTranslated plumbing; gate POSIX APIs behind `cfg(unix)`
- AHK: update Brainstorm, Settings, WindowManager modules
- Otoji submodule bumps (nonce-protected polish tags, XML-tag polish output)

## Test plan

- [ ] Build Windows release and verify DLLs are bundled in zip
- [ ] Test PTT via TCP control socket
- [ ] Verify Space+, opens preferences on Windows
- [ ] Confirm voice PTT type_text / clipboard works end-to-end
- [ ] macOS build unaffected (POSIX gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)