### PR TITLE
feat(voice): default stt_polish_chain to length-gated chain

### DIFF
--- a/rs/core/src/modules/voice.rs
+++ b/rs/core/src/modules/voice.rs
@@ -286,7 +286,7 @@ impl VoiceModule {
                 llm_model: String::new(),
                 stt_correction: false,
                 tts_chain: "elevenlabs:rachel,gemini-2.5-flash-preview-tts,openai:tts-1,msedge,native".to_string(),
-                stt_polish_chain: "mlx:qwen2.5-3b,llm-corrector,raw".to_string(),
+                stt_polish_chain: "min-chars:15,min-duration:5s,mlx:qwen2.5-3b,llm-corrector,raw".to_string(),
                 aec_gain: 15.0,
                 noise_gate: 0.003,
                 speech_start_prob: 0.8,
@@ -2111,7 +2111,11 @@ fn polish_stt_result(
     corrector: &mut Option<crate::stt_corrector::SttCorrector>,
     chain: &str,
 ) -> String {
-    let chain = if chain.is_empty() { "mlx,gemini,llm,raw" } else { chain };
+    let chain = if chain.is_empty() {
+        "min-chars:15,min-duration:5s,mlx,gemini,llm,raw"
+    } else {
+        chain
+    };
     polish_stt_with_chain(raw_text, audio_samples, corrector, chain)
 }
 

--- a/rs/core/src/state.rs
+++ b/rs/core/src/state.rs
@@ -120,7 +120,7 @@ impl Default for ClxConfig {
             elevenlabs_api_key: String::new(),
             stt_correction:     false,
             tts_chain:          "elevenlabs:rachel,gemini-2.5-flash-preview-tts,openai:tts-1,msedge,native".to_string(),
-            stt_polish_chain:   "mlx:qwen2.5-3b,llm-corrector,raw".to_string(),
+            stt_polish_chain:   "min-chars:15,min-duration:5s,mlx:qwen2.5-3b,llm-corrector,raw".to_string(),
             aec_gain:            15.0,
             noise_gate:          0.003,
             speech_start_prob:   0.8,


### PR DESCRIPTION
Updates the new-install default in both spots that hold it
(\`state.rs\` LiveConfig and \`voice.rs\` VoiceLiveConfig) to:

\`\`\`
min-chars:15,min-duration:5s,mlx:qwen2.5-3b,llm-corrector,raw
\`\`\`

Plus the empty-chain fallback in \`polish_stt_result\`.

## Why
Backed by [\`lib/otoji/docs/2026-05-14-polish-bench.md\`](https://github.com/snomiao/otoji/blob/main/docs/2026-05-14-polish-bench.md) §5 — LLM polish degrades CER ~6× on short voice commands (10.8% → 63.6% with qwen2.5:7b). Length gating skips polish for those while preserving it for long dictation.

Bumps the \`lib/otoji\` submodule to pick up the parallel default change in \`config.rs\` / \`otoji_settings.html\` ([snomiao/otoji#16](https://github.com/snomiao/otoji/pull/16)).

Existing user configs unaffected — \`serde(default)\` only applies on fresh installs.

## Test plan
- [x] Length-gate unit tests still pass (4/4 from #139)
- [x] \`./build.sh\` succeeds, clx restarts cleanly
- [ ] Smoke test: short Space+V command (< 15 chars) → log shows \`gated by min-chars:15\`
- [ ] Long dictation continues to flow through MLX polish if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)