### PR TITLE
ci(rust): skip irrelevant platform builds via path filter

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -13,9 +13,41 @@ on:
       - ".github/workflows/ci-rust.yml"
 
 jobs:
+  # Detect which parts of the rs/ tree changed. Adapter-only PRs skip the
+  # other platforms; core / workspace-root changes still fan out to all
+  # three platform jobs because each one also tests capslockx-core.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+      windows: ${{ steps.filter.outputs.windows }}
+      linux: ${{ steps.filter.outputs.linux }}
+      macos: ${{ steps.filter.outputs.macos }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - 'rs/core/**'
+              - 'rs/Cargo.toml'
+              - 'rs/Cargo.lock'
+              - 'rs/tools/**'
+              - '.github/workflows/ci-rust.yml'
+            windows:
+              - 'rs/adapters/windows/**'
+            linux:
+              - 'rs/adapters/linux/**'
+            macos:
+              - 'rs/adapters/macos/**'
+
   build-and-test:
     name: Build & Test (windows-latest / x86_64-pc-windows-msvc)
     runs-on: windows-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.windows == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -59,6 +91,8 @@ jobs:
   build-linux:
     name: Build & Test (ubuntu-latest / x86_64-unknown-linux-gnu)
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.linux == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -97,6 +131,8 @@ jobs:
   build-macos:
     name: Build & Test (macos-latest / aarch64-apple-darwin)
     runs-on: macos-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.macos == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -132,7 +168,8 @@ jobs:
   coverage:
     name: Coverage report (capslockx-core, lib only)
     runs-on: ubuntu-latest
-    needs: build-linux
+    needs: [changes, build-linux]
+    if: ${{ needs.changes.outputs.core == 'true' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Adds a \`changes\` detection job using \`dorny/paths-filter\` that classifies each PR's diff into core / windows / linux / macos buckets. Each platform-specific build is gated so adapter-only PRs no longer fan out to every runner.

## Behavior
| diff scope | windows | linux | macos | coverage |
|---|---|---|---|---|
| core / workspace root | ✅ | ✅ | ✅ | ✅ |
| adapters/windows only | ✅ | skip | skip | skip |
| adapters/linux only | skip | ✅ | skip | skip |
| adapters/macos only | skip | skip | ✅ | skip |
| no rs/** | skip | skip | skip | skip |

## Caveat
Skipped jobs report \`conclusion: skipped\` to GitHub's required-checks gate. If branch protection requires specific check names, either:
1. Drop the platform checks from the required list, or
2. Add an \`always() && success()\` umbrella job and make that the single required check.

Left for a follow-up once we see how this behaves in practice.

## Test plan
- [ ] CI: this PR itself only touches the workflow, so it falls under the \`core\` filter (workflow path) — all three platform jobs should still run.
- [ ] Open a follow-up PR touching only \`rs/adapters/macos/**\` and verify only the macOS job runs.